### PR TITLE
Clarify and streamline Distributions.md (e.g. about Java)

### DIFF
--- a/src/docs/getting-started/Distributions.md
+++ b/src/docs/getting-started/Distributions.md
@@ -1,26 +1,36 @@
 
-Freeplane is available for differents Operating Systems. All Freeplane setup files are available for [download here](https://sourceforge.net/projects/freeplane/files/freeplane%20stable).
+Freeplane is available for different Operating Systems. All Freeplane setup files are available for [download here](https://sourceforge.net/projects/freeplane/files/freeplane%20stable).
 
 Please find below recommendations to choose which **file to download before installing Freeplane on your computer**.
 
 <!-- toc -->
 
+# Java runtime requirement
+
+Freeplane requires a Java runtime:
+- some of the distributions below embed Java, so nothing else is needed,
+- but the other distributions require **Java to be installed independently**.
+
+When using an independently installed Java runtime, it needs to be of a compatible version number (see details for each distribution). The version to be used by Freeplane can be configured using the [FREEPLANE_JAVA_HOME](Command-line_options_and_configuration.md#select-java-installation-used-to-run-freeplane) environment variable.
+
 # Distributions for Microsoft Windows
 
 * **Freeplane-Setup-with-Java-xxx.exe**: Windows installer with embedded Java.
-* **Freeplane-Setup-xxx.exe**: Windows installer which requires Java 8 to 22 to be installed independently. To use this version set environment variable path  [FREEPLANE_JAVA_HOME](Command-line_options_and_configuration.md#select-java-installation-used-to-run-freeplane).
+* **Freeplane-Setup-xxx.exe**: Windows installer which requires Java 8 to 22 to be installed.
 * **FreeplanePortable-xxx.paf.exe**: runs on Windows using [Portable Apps](https://portableapps.com/) launcher.
 Requires [Open JDK JRE64 portable java version 15](https://sourceforge.net/projects/portableapps/files/OpenJDK%20JRE%20Portable/OpenJDKJRE64_15.0.2_Build_7.paf.exe/download) to be installed on your portable app device. It saves user configuration files on the same device.
-* **freeplane_bin-xxx.zip**: archive without installer. It requires Java 11 to 17 to be installed. To use this version set environment variable path [FREEPLANE_JAVA_HOME](Command-line_options_and_configuration.md#select-java-installation-used-to-run-freeplane).
+* **freeplane_bin-xxx.zip**: archive without installer. It requires Java 11 to 21 to be installed.
 
 # Distributions for Apple macOS
 
-* **Freeplane-xxx-intel.dmg**: distribution with embedded java for macOS with intel or m1 processor.  This distribution includes adaptive Look and Feel VAqua.
-* **Freeplane-xxx-apple.dmg**: distribution with embedded java for macOS with m1 processor. This distribution does not include adaptive Look and Feel VAqua.
+* **Freeplane-xxx-intel.dmg**: distribution with embedded Java for macOS with an Intel or Apple M1/M2/... processor
+* **Freeplane-xxx-apple.dmg**: distribution with embedded Java for macOS with an Apple M1/M2/... processor.
+
+Those distributions do not include the adaptive Look and Feel VAqua.
 
 # Distributions for Linux
 
 * **freeplane_xxx~upstream-1_all.deb**: Debian installer compliant with differents Linux derivatives.
 * **freeplane_bin-xxx.zip**: archive without installer. 
 
-They both requires Java 11 to 17 to be installed. To use them, set environment variable path [FREEPLANE_JAVA_HOME](Command-line_options_and_configuration.md#select-java-installation-used-to-run-freeplane).
+They both require Java 11 to 21 to be installed.


### PR DESCRIPTION
This partially addresses issue https://github.com/freeplane/freeplane/issues/2642 and clarify Java requirements.

In the end, I've grouped common info on Java in a dedicated section, so as to remove duplication in the subsequent ones.

Ideally, the Java version requirement could be factored out as well. However, the requirement are presently different for each OS, so I've kept it distributed. However, considering the discrepancy between the [Distributions](https://docs.freeplane.org/getting-started/Distributions.html) and [FREEPLANE_JAVA_HOME](https://docs.freeplane.org/getting-started/Command-line_options_and_configuration.html#select-java-installation-used-to-run-freeplane) doc, I suspect that it is not fully stabilized.